### PR TITLE
Add mention of reportportal-extensions-skippable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ And [how](https://github.com/reportportal/commons-net/blob/master/docs/Logging.m
 
 
 # Useful extensions
+- [Skippable](https://github.com/nvborisenko/reportportal-extensions-skippable) marks skipped tests as `No Defect` automatically
 - [SourceBack](https://github.com/nvborisenko/reportportal-extensions-sourceback) adds piece of test code where test was failed
 - [Insider](https://github.com/nvborisenko/reportportal-extensions-insider) brings more reporting capabilities without coding like methods invocation as nested steps
 


### PR DESCRIPTION
I was finding my skipped / ignored xunit tests were getting marked as "To Investigate", even though I'd previously marked them as "no defect".

Raising in the [reportportal slack channel](https://reportportal.slack.com/archives/C2GTJTTNH/p1677009519562869) I was recommended to use https://github.com/nvborisenko/reportportal-extensions-skippable.

I'm adding here to help future travellers find it easier.