### PR TITLE
Log a message every minute while sending results to Report Portal

### DIFF
--- a/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
+++ b/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
@@ -56,6 +56,13 @@ namespace ReportPortal.XUnitReporter
 
                     Logger.LogMessage("Waiting to finish sending results to Report Portal server...");
 
+                    //log a message saying "we're still doing stuff", to avoid the appearance of hung builds 
+                    using var timer = new Timer(
+                        _ => Logger.LogMessage($"Still sending results to Report Portal server..."),
+                        null,
+                        TimeSpan.FromMinutes(1),
+                        Timeout.InfiniteTimeSpan);
+
                     var stopWatch = Stopwatch.StartNew();
 
                     _launchReporter.Sync();

--- a/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
+++ b/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -52,6 +53,10 @@ namespace ReportPortal.XUnitReporter
                 Logger.LogMessage("Waiting to finish sending results to Report Portal server...");
 
                 var stopWatch = Stopwatch.StartNew();
+
+                _launchReporter.Finish(new FinishLaunchRequest { EndTime = DateTime.UtcNow });
+
+                Logger.LogMessage("Waiting to finish sending results to Report Portal server...");
 
                 //log a message saying "we're still doing stuff", to avoid the appearance of hung builds 
                 using (new Timer(

--- a/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
+++ b/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
@@ -56,16 +56,17 @@ namespace ReportPortal.XUnitReporter
 
                     Logger.LogMessage("Waiting to finish sending results to Report Portal server...");
 
-                    //log a message saying "we're still doing stuff", to avoid the appearance of hung builds 
-                    using var timer = new Timer(
-                        _ => Logger.LogMessage($"Still sending results to Report Portal server..."),
-                        null,
-                        TimeSpan.FromMinutes(1),
-                        Timeout.InfiniteTimeSpan);
-
                     var stopWatch = Stopwatch.StartNew();
 
-                    _launchReporter.Sync();
+                    //log a message saying "we're still doing stuff", to avoid the appearance of hung builds 
+                    using (new Timer(
+                               _ => Logger.LogMessage($"Still sending results to Report Portal server..."),
+                               null,
+                               TimeSpan.FromMinutes(1),
+                               Timeout.InfiniteTimeSpan))
+                    {
+                        _launchReporter.Sync();
+                    }
 
                     Logger.LogMessage($"Results are sent to Report Portal server. Sync duration: {stopWatch.Elapsed}");
                     Logger.LogMessage(_launchReporter.StatisticsCounter.ToString());

--- a/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
+++ b/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
@@ -54,10 +54,6 @@ namespace ReportPortal.XUnitReporter
 
                 var stopWatch = Stopwatch.StartNew();
 
-                _launchReporter.Finish(new FinishLaunchRequest { EndTime = DateTime.UtcNow });
-
-                Logger.LogMessage("Waiting to finish sending results to Report Portal server...");
-
                 //log a message saying "we're still doing stuff", to avoid the appearance of hung builds 
                 using (new Timer(
                            _ => Logger.LogMessage($"Still sending results to Report Portal server..."),


### PR DESCRIPTION
We use the `----blame-hang-timeout` flag to `dotnet test` so that we can get a process dump when a test hangs.
We were setting this to `5m`, but found that occasionally the publishing would take more than this time to send all the test results / log messages to the server.

When report portal took too long, the "hang detection" process would kill the test run.

This PR adds a log message every minute while waiting for all logs / test results to finish sending.

Note: I haven't been able to test this locally 😢. I did try, honest. 