### PR TITLE
Don't affect regular tests executions if reporting process finished with errors 

### DIFF
--- a/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
+++ b/src/ReportPortal.XUnitReporter/ReportPortalMessageHandler.Assembly.cs
@@ -69,7 +69,7 @@ namespace ReportPortal.XUnitReporter
             }
             catch (Exception exp)
             {
-                Logger.LogError(exp.ToString());
+                Logger.LogWarning(exp.ToString());
             }
         }
     }


### PR DESCRIPTION
Fix [issue 24](https://github.com/reportportal/agent-net-xunit/issues/24)
Replace log error with log warning as xunit runner treats logged errors as real errors